### PR TITLE
Fix selected option styling issues in Safari and missing aria attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 3.1.3
+# 3.1.4
+
+### Bug Fixes
+
+* :lipstick: fix misalignment issue with default min height ([a5041d7](https://github.com/ng-select/ng-select/commit/a5041d719d2089342fb506e6be12be7aa8727d41))
+
+## 3.1.3
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 3.1.1
+# 3.1.2
+
+### Bug Fixes
+
+* :wheelchair: add back missing describedBy attribute to input ([ffcbbd3](https://github.com/ng-select/ng-select/commit/ffcbbd322b2028b3d293abce32b9ff0fdf7e57e4))
+
+## 3.1.1
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 3.1.2
+# 3.1.3
+
+### Bug Fixes
+
+* :lipstick: fix misalignment issue with default min height ([a5041d7](https://github.com/ng-select/ng-select/commit/a5041d719d2089342fb506e6be12be7aa8727d41))
+
+## 3.1.2
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,41 +1,27 @@
-# Changelog
+# 3.1.1
 
-Started to maintain versions made from Common App for forked version.
+### Bug Fixes
 
-## 3.1.0
-
-### Feature
-
-- Update forked repo to latest version from ng-select to upgrade ng-select to Angular 9
-- Remove theme stylesheets as styles have been ported to direct SCSS files
-
-## 3.0.2
-
-### Bug fixes
-
-- Remove hostbinding from dropdown panel which was cancelling out the ID applied directly, causing aria-controls to break
-- Use aria-labelledby instead of aria-describedby for input labelling
-- Fix incorrect role applied to single-select chosen values
-
-## 3.0.1
-
-### Bug fixes
-
-- Update clear button text to 'Clear selection' for better applications across single or multiselect dropdowns
-- Add non-color-based focus state to clear button
-- Remove outline from input on focus to counter Chromium's new default focus states (active focus styles is handled higher up in the component)
-
-## 3.0.0
-
-### Major release
-
-Continued versioning from last iteration of CA release (2.7.*). This release is considered major as it was fully rolled back prior to CA changes, and a11y and styling changes were introduced manually to resolve merge issues and some poor branch management practices.
+* :wheelchair: remove duplicative listbox role and simplify dropdown content area ([1fedcaf](https://github.com/ng-select/ng-select/commit/1fedcafddf62fe3fc72dde69dd1176a797106c9e))
 
 ### Features
 
-- Improved accessibility
-- Updated styles to match new design system for Rec
+* :lipstick: remove redundant selected class, rely on option-level ([5cc318c](https://github.com/ng-select/ng-select/commit/5cc318c828f02e9c8d324fbc75603b4b9f9d19ab))
 
-### Fixes
+## 3.1.0
 
-- Resolve issue where selected values and placeholders would not show up
+### Bug Fixes
+
+* remove github flows and templates ([71348b4](https://github.com/ng-select/ng-select/commit/71348b436dfa8d6fac0edb6c233adba367089f6c))
+* resolve merge conflicts resulting in duplicative props/functions ([eaf7de5](https://github.com/ng-select/ng-select/commit/eaf7de53d048c78e2d8e3093d460805665db370e))
+* revert commented out default theme ([06f1d95](https://github.com/ng-select/ng-select/commit/06f1d95937a69d07c86c9332d3f848fc01f955f9))
+* **a11y:** add back a focus state that isn't just a color change ([775334e](https://github.com/ng-select/ng-select/commit/775334e710bdb0405bc981c96384740eec401e68))
+* **a11y:** remove autocomplete attr again as its used incorrectly ([195fd3d](https://github.com/ng-select/ng-select/commit/195fd3de5f843fdc5b371da5f40409229e709f4e))
+* **a11y:** remove optional role when chosen value is in single select ([f011931](https://github.com/ng-select/ng-select/commit/f0119319a9df7a6f1124cfb68293dae857b39952))
+* **a11y:** update to focus style for Chromium update ([fb133a7](https://github.com/ng-select/ng-select/commit/fb133a79c6c7b787ea42452a0ece4677e95f77c8))
+* **input:** add missing attribute setting ([142ec02](https://github.com/ng-select/ng-select/commit/142ec027aa694c49a71bbed006fc44dfc9772037))
+* **publish:** remove public flag ([2bb35ac](https://github.com/ng-select/ng-select/commit/2bb35ac593e124bfa55b3aaf58fc7dbf012fc353))
+
+### Features
+
+* **themes:** :fire: remove theme stylesheets as they are unused ([f4cfe44](https://github.com/ng-select/ng-select/commit/f4cfe44eb6135791b7dde72140bc84b2dd9b0280))

--- a/src/ng-select/lib/ng-dropdown-panel.component.ts
+++ b/src/ng-select/lib/ng-dropdown-panel.component.ts
@@ -40,11 +40,8 @@ const SCROLL_SCHEDULER = typeof requestAnimationFrame !== 'undefined' ? animatio
         <div *ngIf="headerTemplate" class="ng-dropdown-header">
             <ng-container [ngTemplateOutlet]="headerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>
         </div>
-        <div #scroll class="ng-dropdown-panel-items scroll-host">
-            <div #padding [class.total-padding]="virtualScroll"></div>
-            <div #content [class.scrollable-content]="virtualScroll && items.length" [id]="dropdownId" role="listbox">
-                <ng-content></ng-content>
-            </div>
+        <div #scroll #padding #content class="ng-dropdown-panel-items scroll-host">
+            <ng-content></ng-content>
         </div>
         <div *ngIf="footerTemplate" class="ng-dropdown-footer">
             <ng-container [ngTemplateOutlet]="footerTemplate" [ngTemplateOutletContext]="{ searchTerm: filterValue }"></ng-container>

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -53,6 +53,7 @@
                    [attr.aria-autocomplete]="searchable ? 'both' : null"
                    [attr.aria-activedescendant]="isOpen ? itemsList?.markedItem?.htmlId : null"
                    [attr.aria-controls]="isOpen ? dropdownId : null"
+                   [attr.aria-describedby]="describedBy"
                    [attr.aria-labelledby]="labelledBy"
                    [attr.aria-expanded]="isOpen ? 'true' : 'false'"
                    aria-haspopup="true"

--- a/src/ng-select/lib/ng-select.component.html
+++ b/src/ng-select/lib/ng-select.component.html
@@ -127,7 +127,7 @@
              [attr.id]="item?.htmlId">
 
             <ng-template #defaultOptionTemplate>
-                <svg class="ng-option-icon" [class.is-selected]="item.selected" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" viewBox="0 0 512 512">
+                <svg class="ng-option-icon" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" focusable="false" viewBox="0 0 512 512">
                     <path fill="currentColor" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"/>
                 </svg>
 

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -309,10 +309,6 @@ $ng-option-active-color: #fff;
       grid-area: selected-icon;
       width: 100%;
       height: 1.5em;
-
-      &.is-selected {
-        display: block;
-      }
     }
 
     .ng-option-label {
@@ -352,6 +348,11 @@ $ng-option-active-color: #fff;
 
     &:focus {
       text-decoration: underline;
+    }
+
+    // Selected state
+    &.ng-option-selected .ng-option-icon {
+      display: block;
     }
   } // END ng-option
 

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -93,7 +93,7 @@ $ng-option-active-color: #fff;
     grid-area: value;
     display: flex;
     flex: 1;
-    min-height: 43px; // Ensure a minimum height when no value is chosen
+    min-height: 42px; // Ensure a minimum height when no value is chosen
     height: 100%;
     padding: .55rem .25rem .65rem .75rem;
 

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -95,7 +95,7 @@ $ng-option-active-color: #fff;
     flex: 1;
     min-height: 42px; // Ensure a minimum height when no value is chosen
     height: 100%;
-    padding: .55rem .25rem .65rem .75rem;
+    padding: .45rem .25rem .65rem .75rem;
 
     .ng-input {
       opacity: 0;

--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonapp/ng-select",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Common App fork of ng-select",
   "author": "@ng-select/ng-select",
   "contributors": [

--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonapp/ng-select",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Common App fork of ng-select",
   "author": "@ng-select/ng-select",
   "contributors": [

--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonapp/ng-select",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "Common App fork of ng-select",
   "author": "@ng-select/ng-select",
   "contributors": [

--- a/src/ng-select/package.json
+++ b/src/ng-select/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@commonapp/ng-select",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Common App fork of ng-select",
   "author": "@ng-select/ng-select",
   "contributors": [


### PR DESCRIPTION
**3.1.1** fixes the open defects for PTS-11622:

https://cawiki.atlassian.net/browse/PTS-12005  
https://cawiki.atlassian.net/browse/PTS-12006

*   There was a redundant selected class being applied to the icon directly while an existing selected class was applied to the option itself. Simplifying this creates a safer default setup for selected options

**3.1.2** fixes 2 orphan defects related to accessibility:

https://cawiki.atlassian.net/browse/PTS-12027  
https://cawiki.atlassian.net/browse/PTS-10670

*   Remove a duplicated listbox role div inside of the dropdown component
*   Add back `aria-described` by to the input, which was replaced with `labelledby` in an earlier patch accidentally

**3.1.3** fixes a height issue causing ng-select elements to be 1px taller than other form elements

**3.1.4** fixes input padding causing selected values to be pushed too far down

Additionally includes a simplification and update to the changelog file to use the new conventional commit style.