### PR TITLE
Adjustments to option sizing and alignment after system font changes

### DIFF
--- a/src/demo/index.html
+++ b/src/demo/index.html
@@ -7,7 +7,11 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script src="https://use.fontawesome.com/7d64cb55fa.js"></script>
     <script async defer src="https://buttons.github.io/buttons.js"></script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="icon" type="image/x-icon" href="favicon.ico">
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Figtree:ital,wght@0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=swap" rel="stylesheet">
 </head>
 <body>
     <demo-app>Loading ng-select</demo-app>

--- a/src/demo/style/_content.scss
+++ b/src/demo/style/_content.scss
@@ -1,3 +1,7 @@
+body {
+  font-family: 'Figtree', sans-serif;
+}
+
 .bd-title {
   margin-top: .5rem;
   margin-bottom: .5rem;

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -1,13 +1,15 @@
-$ng-select-border: #333;
+$ng-select-border: var(--forge-color-gray-900, hsl(0, 0%, 22%));
 $ng-select-border-radius: 4px;
 $ng-select-error: #ff0011;
-$ng-select-dropdown-background: #fff;
+$ng-select-dropdown-background: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
 
 $ng-value-background-color: #ededed;
 $ng-value-border-radius: 999px;
 
-$ng-option-active-background: #333;
-$ng-option-active-color: #fff;
+$ng-option-active-background: var(--forge-color-gray-800, hsl(0, 0%, 31%));
+$ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
+
+
 
 
 @mixin truncate() {
@@ -18,9 +20,10 @@ $ng-option-active-color: #fff;
 
 
 .ng-select {
-  position: relative;
-  display: block;
   background-color: rgb(255, 255, 255);
+  display: block;
+  font-family: inherit; // Ensure ng-select uses the current system UI
+  position: relative;
 
   // Container for value, clear, and arrow
   .ng-select-container {
@@ -297,13 +300,12 @@ $ng-option-active-color: #fff;
     display: grid;
     grid-template: "selected-icon value-text" auto / 1rem 1fr;
     gap: 0 .5rem;
-    padding: .6rem .75rem .7rem;
+    padding: .75rem;
 
     .ng-option-icon {
       display: none;
       grid-area: selected-icon;
       width: 100%;
-      height: 1.5em;
     }
 
     .ng-option-label {

--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -23,6 +23,8 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
   background-color: rgb(255, 255, 255);
   display: block;
   font-family: inherit; // Ensure ng-select uses the current system UI
+  font-size: 1rem;
+  line-height: 1.2;
   position: relative;
 
   // Container for value, clear, and arrow
@@ -306,6 +308,7 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
       display: none;
       grid-area: selected-icon;
       width: 100%;
+      padding-top: 1px; // Text alignment
     }
 
     .ng-option-label {
@@ -313,7 +316,7 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
 
       // When not showing a selectable option, allow text to span full width
       &:only-child {
-          grid-column: 1 / 3;
+        grid-column: 1 / 3;
       }
     }
 


### PR DESCRIPTION
## Description

1. Added Figtree to the demo page for more accurate testing of changes in the examples
2. Adjusted colors to match expected theming out of the box
3. Adjusted the alignment of options after the Figtree change
    * Standardized padding in options to be equal
    * Slight push on the selected icons to align with line-heights in options