### PR TITLE
PNMA-301 - Reduce block padding to better match CA inputs

### DIFF
--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -99,7 +99,7 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
     flex: 1;
     align-items: center;
     padding-left: .75rem;
-    padding-block: .75rem;
+    padding-block: .7rem; // Creates a sub-pixel similar height to CA inputs
 
     .ng-input {
       opacity: 0;


### PR DESCRIPTION
## Description
 
https://cawiki.atlassian.net/browse/PNMA-301

- Reduced block padding .05 which brings ng-select and mat-form-field height within .08px of each other