### PR TITLE
PNMA-301 - Fix searchable inputs taking up space even when not used

### DIFF
--- a/src/ng-select/lib/ng-select.component.scss
+++ b/src/ng-select/lib/ng-select.component.scss
@@ -102,6 +102,7 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
     padding-block: .7rem; // Creates a sub-pixel similar height to CA inputs
 
     .ng-input {
+      flex: 1;
       opacity: 0;
 
       > input {
@@ -113,7 +114,9 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
         cursor: default;
 
         &[readonly] {
+          padding: 0;
           user-select: none;
+          width: 0;
         }
 
         &::placeholder {
@@ -133,11 +136,6 @@ $ng-option-active-color: var(--forge-color-neutral-light, hsl(0, 0%, 100%));
 
   // Type-based styles
   &.ng-select-single {
-    .ng-input {
-      left: .75rem;
-      width: 100%;
-    }
-
     .ng-value-icon {
       display: none;
     }


### PR DESCRIPTION
## Description

Coming out of an Early Testing finding, ng-selects that weren't searchable still had fullsize inputs, creating text-wrapping in values and allowing typing even though it wouldn't function.

The changes here "hide" the input for non-searchable selects again, and fixes and issue where the input could "squish" chosen values.